### PR TITLE
fix typedoc run-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",
-    "typedoc": "typedoc --out ./docs/ ./pacages/",
+    "typedoc": "typedoc --out ./docs/ ./packages/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
the `typedoc` run-script failed as follows. typo?

```
% npm run typedoc

> mesh.js@1.0.0 typedoc
> typedoc --out ./docs/ ./pacages/

error Unable to find any entry points. Make sure TypeDoc can find your tsconfig
```
